### PR TITLE
Add gpfs libraries if needed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,6 +30,11 @@ AC_CHECK_FUNCS([getpagesize gettimeofday memset mkdir pow putenv realpath regcom
 AC_SEARCH_LIBS([sqrt], [m], [],
         [AC_MSG_ERROR([Math library not found])])
 
+AS_IF([test "$ac_cv_header_gpfs_h" = "yes" -o "$ac_cv_header_gpfs_fcntl_h" = "yes"], [
+	AC_SEARCH_LIBS([gpfs_fcntl], [gpfs], [],
+	  [AC_MSG_ERROR([Library containing gpfs_fcntl symbols not found])])
+])
+
 # Check for system capabilities
 AC_SYS_LARGEFILE
 


### PR DESCRIPTION
Commit aa604c1d38de803aa0db3f3abb5515e0ed1857ea introduced gpfs_fcntl
operations, depending if gpfs.h and gpfs_fcntl.h were found.  These
routines need the GPFS client library.  This configure check will bring
in libgpfs -- you will still need to set LDFLAGS and CPPFLAGS if gpfs is
installed in some non-default locaiton (as it is on Blue Gene).

fixes https://github.com/chaos/ior/issues/15