### PR TITLE
explicitly disable O_CREAT and O_EXCL when doing read-only test

### DIFF
--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -122,8 +122,10 @@ static void CheckRunSettings(IOR_test_t *tests)
                     && (params->openFlags & IOR_RDWR)) {
 
                         params->openFlags &= ~(IOR_RDWR);
-                        if (params->readFile | params->checkRead)
+                        if (params->readFile | params->checkRead) {
                                 params->openFlags |= IOR_RDONLY;
+                                params->openFlags &= ~(IOR_CREAT|IOR_EXCL);
+                        }
                         else
                                 params->openFlags |= IOR_WRONLY;
                 }


### PR DESCRIPTION
Read-only tests using the MPI-IO interface were failing because `IOR_CREAT` was being carried over from the default settings defined in `init_IOR_Param_t`, resulting in this error:

    MPI_FILE_OPEN(119): Cannot use MPI_MODE_CREATE or MPI_MODE_EXCL with MPI_MODE_RDONLY , (aiori-MPIIO.c:145)

This explicitly unsets `IOR_CREAT` (and `IOR_EXCL`, just as good measure) so read-only tests with MPI-IO work again.