### PR TITLE
add support for tuning BeeGFS parameters

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@ AX_PROG_CC_MPI
 # Checks for libraries.
 
 # Checks for header files.
-AC_CHECK_HEADERS([fcntl.h libintl.h stdlib.h string.h strings.h sys/ioctl.h sys/param.h sys/statfs.h sys/statvfs.h sys/time.h unistd.h wchar.h plfs.h hdfs.h])
+AC_CHECK_HEADERS([fcntl.h libintl.h stdlib.h string.h strings.h sys/ioctl.h sys/param.h sys/statfs.h sys/statvfs.h sys/time.h unistd.h wchar.h plfs.h hdfs.h beegfs/beegfs.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T

--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -349,6 +349,14 @@ GPFS-SPECIFIC:
 			   all locks.  Might help mitigate lock-revocation
 			   traffic when many proceses write/read to same file.
 
+BeeGFS-SPECIFIC (POSIX only):
+================
+  * beegfsNumTargets     - set the number of storage targets to use
+
+  * beegfsChunkSize      - set the striping chunk size. Must be a power of two,
+                             and greater than 64kiB, (e.g.: 256k, 1M, ...)
+
+
 ***********************
 * 5. VERBOSITY LEVELS *
 ***********************

--- a/src/ior.c
+++ b/src/ior.c
@@ -242,6 +242,9 @@ void init_IOR_Param_t(IOR_param_t * p)
         p->io_buf = NULL;
         p->etags = NULL;
         p->part_number = 0;
+
+        p->beegfs_numTargets = -1;
+        p->beegfs_chunkSize = -1;
 }
 
 /*

--- a/src/ior.h
+++ b/src/ior.h
@@ -205,6 +205,9 @@ typedef struct
     int gpfs_hint_access;          /* use gpfs "access range" hint */
     int gpfs_release_token;        /* immediately release GPFS tokens after
                                       creating or opening a file */
+    /* beegfs variables */
+    int beegfs_numTargets;           /* number storage targets to use */
+    int beegfs_chunkSize;            /* srtipe pattern for new files */
 
     int id;                          /* test's unique ID */
     int intraTestBarriers;           /* barriers between open/op and op/close */

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -25,6 +25,8 @@
 #include "aiori.h"
 #include "parse_options.h"
 
+#define ISPOWEROFTWO(x) ((x != 0) && !(x & (x - 1)))
+
 IOR_param_t initialTestParams;
 
 /*
@@ -298,6 +300,20 @@ void DecodeDirective(char *line, IOR_param_t *params)
                 ERR("ior was not compiled with GPFS hint support");
 #endif
                 params->gpfs_release_token = atoi(value);
+       } else if (strcasecmp(option, "beegfsNumTargets") == 0) {
+#ifndef HAVE_BEEGFS_BEEGFS_H
+                ERR("ior was not compiled with BeeGFS support");
+#endif
+                params->beegfs_numTargets = atoi(value);
+                if (params->beegfs_numTargets < 1)
+                        ERR("beegfsNumTargets must be >= 1");
+        } else if (strcasecmp(option, "beegfsChunkSize") == 0) {
+ #ifndef HAVE_BEEGFS_BEEGFS_H
+                 ERR("ior was not compiled with BeeGFS support"); 
+ #endif
+                 params->beegfs_chunkSize = StringToBytes(value);
+                 if (!ISPOWEROFTWO(params->beegfs_chunkSize) || params->beegfs_chunkSize < (1<<16))
+                         ERR("beegfsChunkSize must be a power of two and >64k");
         } else if (strcasecmp(option, "numtasks") == 0) {
                 params->numTasks = atoi(value);
 		RecalculateExpectedFileSize(params);


### PR DESCRIPTION
Support includes tuning the following parameters:
 - Number of stripe targets (numTargets)
 - Chunk size

Support is enabled if BeeGFS API header files are found during the configure step.