### PR TITLE
StoneWalling with WearOutPhase

### DIFF
--- a/src/ior.c
+++ b/src/ior.c
@@ -169,11 +169,11 @@ int main(int argc, char **argv)
                         sleep(5);
                         printf("\trank %d: awake.\n", rank);
                 }
+                TestIoSys(tptr);
+
                 if(rank == 0 && tptr->params.stoneWallingWearOut){
                   fprintf(stdout, "Pairs deadlineForStonewallingaccessed: %lld\n", (long long) tptr->results->pairs_accessed);
                 }
-
-                TestIoSys(tptr);
         }
 
         if (verbose < 0)
@@ -753,6 +753,8 @@ static void DisplayUsage(char **argv)
                 " -C    reorderTasks -- changes task ordering to n+1 ordering for readback",
                 " -d N  interTestDelay -- delay between reps in seconds",
                 " -D N  deadlineForStonewalling -- seconds before stopping write or read phase",
+                " -O stoneWallingWearOut=1 -- once the stonewalling timout is over, all process finish to access the amount of data",
+                " -O stoneWallingWearOutIterations=N -- stop after processing this number of iterations, needed for reading data back written with stoneWallingWearOut",
                 " -e    fsync -- perform fsync upon POSIX write close",
                 " -E    useExistingTestFile -- do not remove test file before write access",
                 " -f S  scriptFile -- test script name",
@@ -792,8 +794,6 @@ static void DisplayUsage(char **argv)
                 " -W    checkWrite -- check read after write",
                 " -x    singleXferAttempt -- do not retry transfer if incomplete",
                 " -X N  reorderTasksRandomSeed -- random seed for -Z option",
-                " -y    stoneWallingWearOut -- once the stonewalling timout is over, all process finish to access the amount of data",
-                " -1    stoneWallingWearOutIterations stop after processing this number of iterations, needed for reading data back written with -y",
                 " -Y    fsyncPerWrite -- perform fsync after each POSIX write",
                 " -z    randomOffset -- access is to random, not sequential, offsets within a file",
                 " -Z    reorderTasksRandom -- changes task ordering to random ordering for readback",

--- a/src/ior.c
+++ b/src/ior.c
@@ -793,6 +793,7 @@ static void DisplayUsage(char **argv)
                 " -x    singleXferAttempt -- do not retry transfer if incomplete",
                 " -X N  reorderTasksRandomSeed -- random seed for -Z option",
                 " -y    stoneWallingWearOut -- once the stonewalling timout is over, all process finish to access the amount of data",
+                " -1    stoneWallingWearOutIterations stop after processing this number of iterations, needed for reading data back written with -y",
                 " -Y    fsyncPerWrite -- perform fsync after each POSIX write",
                 " -z    randomOffset -- access is to random, not sequential, offsets within a file",
                 " -Z    reorderTasksRandom -- changes task ordering to random ordering for readback",
@@ -2635,13 +2636,13 @@ static IOR_offset_t WriteOrRead(IOR_param_t * test, IOR_results_t * results, voi
                             > test->deadlineForStonewalling));
 
         /* loop over offsets to access */
-        while ((offsetArray[pairCnt] != -1) && !hitStonewall) {
+        while ((offsetArray[pairCnt] != -1) && !hitStonewall ) {
                 dataMoved += WriteOrReadSingle(pairCnt, offsetArray, pretendRank, & transferCount, & errors, test, fd, ioBuffers, access);
                 pairCnt++;
 
                 hitStonewall = ((test->deadlineForStonewalling != 0)
                                 && ((GetTimeStamp() - startForStonewall)
-                                    > test->deadlineForStonewalling));
+                                    > test->deadlineForStonewalling)) || (test->stoneWallingWearOutIterations != 0 && pairCnt == test->stoneWallingWearOutIterations) ;
         }
         if (test->stoneWallingWearOut){
           MPI_CHECK(MPI_Allreduce(& pairCnt, &results->pairs_accessed,

--- a/src/ior.h
+++ b/src/ior.h
@@ -142,6 +142,7 @@ typedef struct
     int storeFileOffset;             /* use file offset as stored signature */
     int deadlineForStonewalling;     /* max time in seconds to run any test phase */
     int stoneWallingWearOut;         /* wear out the stonewalling, once the timout is over, each process has to write the same amount */
+    int stoneWallingWearOutIterations; /* the number of iterations for the stonewallingWearOut, needed for readBack */
     int maxTimeDuration;             /* max time in minutes to run each test */
     int outlierThreshold;            /* warn on outlier N seconds from mean */
     int verbose;                     /* verbosity */

--- a/src/ior.h
+++ b/src/ior.h
@@ -5,7 +5,7 @@
  *       8-chars of indenting is ridiculous.  If you really want 8-spaces,
  *       then change the mode-line to use tabs, and configure your personal
  *       editor environment to use 8-space tab-stops.
- *       
+ *
  */
 /******************************************************************************\
 *                                                                              *
@@ -67,7 +67,7 @@ enum PACKET_TYPE
 /* A struct to hold the buffers so we can pass 1 pointer around instead of 3
  */
 
-typedef struct IO_BUFFERS 
+typedef struct IO_BUFFERS
 {
     void* buffer;
     void* checkBuffer;
@@ -141,6 +141,7 @@ typedef struct
     int useExistingTestFile;         /* do not delete test file before access */
     int storeFileOffset;             /* use file offset as stored signature */
     int deadlineForStonewalling;     /* max time in seconds to run any test phase */
+    int stoneWallingWearOut;         /* wear out the stonewalling, once the timout is over, each process has to write the same amount */
     int maxTimeDuration;             /* max time in minutes to run each test */
     int outlierThreshold;            /* warn on outlier N seconds from mean */
     int verbose;                     /* verbosity */
@@ -215,6 +216,7 @@ typedef struct
 typedef struct {
    double *writeTime;
    double *readTime;
+   size_t pairs_accessed; // number of I/Os done, useful for deadlineForStonewalling
    IOR_offset_t *aggFileSizeFromStat;
    IOR_offset_t *aggFileSizeFromXfer;
    IOR_offset_t *aggFileSizeForBW;

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -169,6 +169,8 @@ void DecodeDirective(char *line, IOR_param_t *params)
                 strcpy(params->hintsFileName, value);
         } else if (strcasecmp(option, "deadlineforstonewalling") == 0) {
                 params->deadlineForStonewalling = atoi(value);
+        } else if (strcasecmp(option, "stoneWallingWearOut") == 0) {
+                params->stoneWallingWearOut = atoi(value);
         } else if (strcasecmp(option, "maxtimeduration") == 0) {
                 params->maxTimeDuration = atoi(value);
         } else if (strcasecmp(option, "outlierthreshold") == 0) {
@@ -430,7 +432,7 @@ IOR_test_t *ReadConfigScript(char *scriptName)
 IOR_test_t *ParseCommandLine(int argc, char **argv)
 {
         static const char *opts =
-          "a:A:b:BcCd:D:eEf:FgG:hHi:Ij:J:kKl:mM:nN:o:O:pPqQ:rRs:St:T:uU:vVwWxX:YzZ";
+          "a:A:b:BcCd:D:eEf:FgG:hHi:Ij:J:kKl:mM:nN:o:O:pPqQ:rRs:St:T:uU:vVwWxX:YzZy";
         int c, i;
         static IOR_test_t *tests = NULL;
 
@@ -523,13 +525,13 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
                                 initialTestParams.dataPacketType = incompressible;
                                 break;
                         case 't': /* timestamp */
-                                initialTestParams.dataPacketType = timestamp;         
+                                initialTestParams.dataPacketType = timestamp;
                                 break;
                         case 'o': /* offset packet */
                                 initialTestParams.storeFileOffset = TRUE;
                                 initialTestParams.dataPacketType = offset;
                                 break;
-                        default: 
+                        default:
                                 fprintf(stdout,
                                         "Unknown arguement for -l  %s generic assumed\n", optarg);
                                 break;
@@ -609,6 +611,9 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
                         break;
                 case 'X':
                         initialTestParams.reorderTasksRandomSeed = atoi(optarg);
+                        break;
+                case 'y':
+                        initialTestParams.stoneWallingWearOut = TRUE;
                         break;
                 case 'Y':
                         initialTestParams.fsyncPerWrite = TRUE;

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -432,7 +432,7 @@ IOR_test_t *ReadConfigScript(char *scriptName)
 IOR_test_t *ParseCommandLine(int argc, char **argv)
 {
         static const char *opts =
-          "a:A:b:BcCd:D:eEf:FgG:hHi:Ij:J:kKl:mM:nN:o:O:pPqQ:rRs:St:T:uU:vVwWxX:YzZy";
+          "a:A:b:BcCd:D:eEf:FgG:hHi:Ij:J:kKl:mM:nN:o:O:pPqQ:rRs:St:T:uU:vVwWxX:YzZy1:";
         int c, i;
         static IOR_test_t *tests = NULL;
 
@@ -611,6 +611,9 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
                         break;
                 case 'X':
                         initialTestParams.reorderTasksRandomSeed = atoi(optarg);
+                        break;
+                case '1':
+                        initialTestParams.stoneWallingWearOutIterations = atoi(optarg);
                         break;
                 case 'y':
                         initialTestParams.stoneWallingWearOut = TRUE;

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -434,7 +434,7 @@ IOR_test_t *ReadConfigScript(char *scriptName)
 IOR_test_t *ParseCommandLine(int argc, char **argv)
 {
         static const char *opts =
-          "a:A:b:BcCd:D:eEf:FgG:hHi:Ij:J:kKl:mM:nN:o:O:pPqQ:rRs:St:T:uU:vVwWxX:YzZy1:";
+          "a:A:b:BcCd:D:eEf:FgG:hHi:Ij:J:kKl:mM:nN:o:O:pPqQ:rRs:St:T:uU:vVwWxX:YzZ";
         int c, i;
         static IOR_test_t *tests = NULL;
 

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -171,6 +171,8 @@ void DecodeDirective(char *line, IOR_param_t *params)
                 params->deadlineForStonewalling = atoi(value);
         } else if (strcasecmp(option, "stoneWallingWearOut") == 0) {
                 params->stoneWallingWearOut = atoi(value);
+        } else if (strcasecmp(option, "stoneWallingWearOutIterations") == 0) {
+                params->stoneWallingWearOutIterations = atoi(value);
         } else if (strcasecmp(option, "maxtimeduration") == 0) {
                 params->maxTimeDuration = atoi(value);
         } else if (strcasecmp(option, "outlierthreshold") == 0) {
@@ -611,12 +613,6 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
                         break;
                 case 'X':
                         initialTestParams.reorderTasksRandomSeed = atoi(optarg);
-                        break;
-                case '1':
-                        initialTestParams.stoneWallingWearOutIterations = atoi(optarg);
-                        break;
-                case 'y':
-                        initialTestParams.stoneWallingWearOut = TRUE;
                         break;
                 case 'Y':
                         initialTestParams.fsyncPerWrite = TRUE;


### PR DESCRIPTION
The patch extends stonewalling with a wear out phase introducing two new options:
-y This enables together with -D N the stonewalling to N seconds however, once write out is complete, it does continue to writeout data on all processes that not reached the maximum number of tuples written
-1 N Forces to access a maximum of N segments with the same parameters, useful if data has been written.

Example:
Write, stonewalling max 10 segments, stonewall timer -D == 0 seconds (for testing):
mpiexec -np 2 ./src/ior -v -y -w -D 0 -b 10m -s 10 -t 10m -k
0: stonewalling pairs accessed globally: 10 this rank: 10
1: stonewalling pairs accessed globally: 10 this rank: 5
So process 1 will now do additional 5 iterations...

Read: this one reads only 5 segments back, normally one would do 10 iterations. 
mpiexec -np 2 ./src/ior -v -y -r -1 5 -b 10m -s 10 -t 10m -k

Note that here is no Stonewalling timer added now if we want to read back *all* the data written before.

Why is -1 needed? The reason is to ensure the exact same pattern as for read, i.e., skipping holes, particularly for random accesses.

Inside the comment "pairs" can be changed to "segments" as the IOR code speech differs from the users. Verified that these offset pairs are actually segments.
