### PR TITLE
fix a bug when make IOR in MacOS will cause a compile error 

### DIFF
--- a/contrib/cbif.c
+++ b/contrib/cbif.c
@@ -36,6 +36,14 @@
 
 #define BYTE_BOUNDARY 8
 
+#ifndef   open64                /* necessary for TRU64 -- */
+#  define open64  open            /* unlikely, but may pose */
+#endif  /* not open64 */                        /* conflicting prototypes */
+
+#ifndef   lseek64               /* necessary for TRU64 -- */
+#  define lseek64 lseek           /* unlikely, but may pose */
+#endif  /* not lseek64 */                        /* conflicting prototypes */
+
 int
 main(int argc, char **argv)
 {

--- a/src/mdtest.c
+++ b/src/mdtest.c
@@ -119,6 +119,9 @@ static int depth;
 /* needed for MPI/IO backend to link correctly */
 int rankOffset = 0;
 
+/* needed for NCMPI backend to link correctly */
+int numTasksWorld = 0;
+
 /*
  * This is likely a small value, but it's sometimes computed by
  * branch_factor^(depth+1), so we'll make it a larger variable,
@@ -1819,6 +1822,9 @@ int main(int argc, char **argv) {
     MPI_Init(&argc, &argv);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &size);
+  
+    /* NCMPI backend uses numTaskWorld as size */
+    numTasksWorld = size;
 
     pid = getpid();
     uid = getuid();


### PR DESCRIPTION
The MacOS doesn't support lseek64 and open64. So when compiling IOR in MacOS will cause error "Undefined symbols for _lseek64 and _open64" in file contrib/cbif.c.