### PR TITLE
change MPI_BYTE to MPI_SIGNED_CHAR

### DIFF
--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -276,26 +276,26 @@ static IOR_offset_t NCMPI_Xfer(int access, void *fd, IOR_size_t * buffer,
         /* access the file */
         if (access == WRITE) {  /* WRITE */
                 if (param->collective) {
-                        NCMPI_CHECK(ncmpi_put_vara_all
+                        NCMPI_CHECK(ncmpi_put_vara_schar_all
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_SIGNED_CHAR),
+                                     bufferPtr),
                                     "cannot write to data set");
                 } else {
-                        NCMPI_CHECK(ncmpi_put_vara
+                        NCMPI_CHECK(ncmpi_put_vara_schar
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_SIGNED_CHAR),
+                                     bufferPtr),
                                     "cannot write to data set");
                 }
         } else {                /* READ or CHECK */
                 if (param->collective == TRUE) {
-                        NCMPI_CHECK(ncmpi_get_vara_all
+                        NCMPI_CHECK(ncmpi_get_vara_schar_all
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_SIGNED_CHAR),
+                                     bufferPtr),
                                     "cannot read from data set");
                 } else {
-                        NCMPI_CHECK(ncmpi_get_vara
+                        NCMPI_CHECK(ncmpi_get_vara_schar
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_SIGNED_CHAR),
+                                     bufferPtr),
                                     "cannot read from data set");
                 }
         }

--- a/src/aiori-NCMPI.c
+++ b/src/aiori-NCMPI.c
@@ -278,24 +278,24 @@ static IOR_offset_t NCMPI_Xfer(int access, void *fd, IOR_size_t * buffer,
                 if (param->collective) {
                         NCMPI_CHECK(ncmpi_put_vara_all
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_BYTE),
+                                     bufferPtr, length, MPI_SIGNED_CHAR),
                                     "cannot write to data set");
                 } else {
                         NCMPI_CHECK(ncmpi_put_vara
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_BYTE),
+                                     bufferPtr, length, MPI_SIGNED_CHAR),
                                     "cannot write to data set");
                 }
         } else {                /* READ or CHECK */
                 if (param->collective == TRUE) {
                         NCMPI_CHECK(ncmpi_get_vara_all
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_BYTE),
+                                     bufferPtr, length, MPI_SIGNED_CHAR),
                                     "cannot read from data set");
                 } else {
                         NCMPI_CHECK(ncmpi_get_vara
                                     (*(int *)fd, var_id, offset, bufSize,
-                                     bufferPtr, length, MPI_BYTE),
+                                     bufferPtr, length, MPI_SIGNED_CHAR),
                                     "cannot read from data set");
                 }
         }


### PR DESCRIPTION
From Pnetcdf 1.7, the MPI datatype corresponding to NC_BYTE  is change from MPI_BYTE to MPI_SIGNED_CHAR. If not change, running IOR with NCMPI will cause a fatal error as below:
ERROR in aiori-NCMPI.c (line 287): cannot write to data set.
ERROR: NetCDF: Not a valid data type or _FillValue type mismatch.