### PR TITLE
Hardens test for MPI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -18,8 +18,12 @@ AC_CANONICAL_HOST
 AM_INIT_AUTOMAKE([check-news dist-bzip2 gnu no-define])
 AM_MAINTAINER_MODE
 
-# Checks for programs.
-AX_PROG_CC_MPI
+# Checks for programs
+
+# We can't do anything without a working MPI
+AX_PROG_CC_MPI(,,[
+    AC_MSG_FAILURE([MPI compiler requested, but couldn't use MPI.])
+])
 
 # No reason not to require modern C at this point
 AC_PROG_CC_C99


### PR DESCRIPTION
Previously, the configure script could fail to find an MPI
implementation but continue regardless. This alters the behaviour so
that the configure script fails if the check for MPI does.