### PR TITLE
Option for benchmarking with user defined data

### DIFF
--- a/doc/USER_GUIDE
+++ b/doc/USER_GUIDE
@@ -74,7 +74,7 @@ These options are to be used on the command line. E.g., 'IOR -a POSIX -b 4K'.
   -J N  setAlignment -- HDF5 alignment in bytes (e.g.: 8, 4k, 2m, 1g)
   -k    keepFile -- don't remove the test file(s) on program exit
   -K    keepFileWithError  -- keep error-filled file(s) after data-checking
-  -l    data packet type-- type of packet that will be created [offset|incompressible|timestamp|o|i|t]
+  -l    data packet type-- type of packet that will be created [offset|incompressible|timestamp|userdata|o|i|t|u]
   -m    multiFile -- use number of reps (-i) for multiple file count
   -M N  memoryPerNode -- hog memory on the node (e.g.: 2g, 75%)
   -n    noFill -- no fill in HDF5 file creation
@@ -280,6 +280,9 @@ GENERAL:
   * summaryAlways        - Always print the long summary for each test.
                            Useful for long runs that may be interrupted, preventing
                            the final long summary for ALL tests to be printed.
+                           
+  * pathToInputFile      - Path to a file with user definded data, as needed for 
+  						   -l u (data packet type =  userdata)  	                   
 
 
 POSIX-ONLY:

--- a/src/ior.h
+++ b/src/ior.h
@@ -55,9 +55,10 @@ extern MPI_Comm testComm;
 enum PACKET_TYPE
 {
     generic = 0,                /* No packet type specified */
-    timestamp=1,                  /* Timestamp packet set with -l */
-    offset=2,                     /* Offset packet set with -l */
-    incompressible=3              /* Incompressible packet set with -l */
+    timestamp=1,                /* Timestamp packet set with -l */
+    offset=2,                   /* Offset packet set with -l */
+    incompressible=3,           /* Incompressible packet set with -l */
+    userdata=4                  /* User data is used to file the buffers */
 
 };
 
@@ -100,6 +101,7 @@ typedef struct
     char platform[MAX_STR];          /* platform type */
     char testFileName[MAXPATHLEN];   /* full name for test */
     char testFileName_fppReadCheck[MAXPATHLEN];/* filename for fpp read check */
+    char pathToInputFile[MAXPATHLEN];/* path to input file */
     char hintsFileName[MAXPATHLEN];  /* full name for hints file */
     char options[MAXPATHLEN];        /* options string */
     int numTasks;                    /* number of tasks for test */
@@ -150,11 +152,12 @@ typedef struct
     unsigned int timeStampSignatureValue; /* value for time stamp signature */
     void * fd_fppReadCheck;          /* additional fd for fpp read check */
     int randomSeed;                  /* random seed for write/read check */
-    int incompressibleSeed;           /* random seed for incompressible file creation */
+    int incompressibleSeed;	     /* random seed for incompressible file creation */
     int randomOffset;                /* access is to random offsets */
     size_t memoryPerTask;            /* additional memory used per task */
     size_t memoryPerNode;            /* additional memory used per node */
-    enum PACKET_TYPE dataPacketType;             /* The type of data packet.  */
+    enum PACKET_TYPE dataPacketType; /* The type of data packet.  */
+    IOR_offset_t userdataFileSize;   /* Size of the file for the userdata from pathtoInputFile */
 
 
     /* POSIX variables */

--- a/src/parse_options.c
+++ b/src/parse_options.c
@@ -167,6 +167,8 @@ void DecodeDirective(char *line, IOR_param_t *params)
                 strcpy(params->platform, value);
         } else if (strcasecmp(option, "testfile") == 0) {
                 strcpy(params->testFileName, value);
+        } else if (strcasecmp(option, "pathToInputFile") == 0) {
+                strcpy(params->pathToInputFile, value);
         } else if (strcasecmp(option, "hintsfilename") == 0) {
                 strcpy(params->hintsFileName, value);
         } else if (strcasecmp(option, "deadlineforstonewalling") == 0) {
@@ -548,6 +550,9 @@ IOR_test_t *ParseCommandLine(int argc, char **argv)
                         case 'o': /* offset packet */
                                 initialTestParams.storeFileOffset = TRUE;
                                 initialTestParams.dataPacketType = offset;
+                                break;
+                        case 'u': /* userdata packet */
+                                initialTestParams.dataPacketType = userdata;
                                 break;
                         default:
                                 fprintf(stdout,


### PR DESCRIPTION
This adds the option to benchmark with user defined data. It is
specifically use full for benchmarking file systems with compression, as
IOR only provides in-compressible or super compressible data (repeating
every 128 bytes). A new flag for the -l (data packet type) `u` is now
present. When this is chosen the data given by the new directive
`pathToInputFile` is read to the buffer. The file has to be at least
the size of blocksize as this is amount of user data used by IOR.
This seams to be sufficient for simulating real data while keeping IOR's
options for access patterns through the parameters transfersize,
blocksize, segmentcount and number of processes working.
This option shouldn't alter IOR's behavior in any other way.
User data should be compatible with Read and Write Checking as the
buffers can be filled with the same data for checking.