### PR TITLE
Fix O_DIRECT option

### DIFF
--- a/src/utilities.c
+++ b/src/utilities.c
@@ -16,6 +16,10 @@
 #  include "config.h"
 #endif
 
+#ifdef __linux__
+#  define _GNU_SOURCE            /* Needed for O_DIRECT in fcntl */
+#endif                           /* __linux__ */
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>


### PR DESCRIPTION
The O_DIRECT option was not working as set_o_direct_flag() were moved to
utilities.c but there the  #define _GNU_SOURCE where missing. This lead
to the Warning "cannot use O_DIRECT".