### PR TITLE
aiori-dfs: Add support for DAOS Pool and Container labels

### DIFF
--- a/README_DAOS
+++ b/README_DAOS
@@ -17,16 +17,15 @@ ior -a DFS [ior_options] [dfs_options]
 mdtest -a DFS [mdtest_options] [dfs_options]
 
 Required Options:
---dfs.pool <pool_uuid>: pool uuid to connect to (has to be created beforehand)
---dfs.svcl <pool_svcl>: pool svcl list (: separated)
---dfs.cont <co_uuid>: container uuid that will hold the encapsulated namespace
+--dfs.pool <pool>: pool label or uuid to connect to (has to be created beforehand)
+--dfs.cont <cont>: container label or uuid that will hold the encapsulated namespace
 
 Optional Options:
 --dfs.group <group_name>: group name of servers with the pool (default: daos_server)
 --dfs.chunk_size <chunk_size>: Chunk size of the files (default: 1MiB)
 --dfs.destroy: flag to destroy the container on finalize (default: no)
 --dfs.oclass <object_class>: specific object class for files (default: SX)
---dfs.dir_oclass <object_class>: specific object class for directories (default: SX)
+--dfs.dir_oclass <object_class>: specific object class for directories (default: S1)
 --dfs.prefix <path>: absolute path to account for DFS files/dirs before the cont root
 
 If prefix is not set, in the IOR options, the file name should be specified on
@@ -35,13 +34,13 @@ container representing the encapsulated namespace is not the same as the system
 namespace the user is executing from.
 
 Examples that should work include:
-  - "ior -a DFS -w -W -o /test1 --dfs.pool <pool_uuid> --dfs.svcl <svc_ranks> --dfs.cont <co_uuid>"
-  - "ior -a DFS -w -W -r -R -o /test2 -b 1g -t 4m -C --dfs.pool <pool_uuid> --dfs.svcl <svc_ranks> --dfs.cont <co_uuid>"
-  - "ior -a DFS -w -r -o /test3 -b 8g -t 1m -C --dfs.pool <pool_uuid> --dfs.svcl <svc_ranks> --dfs.cont <co_uuid>"
+  - "ior -a DFS -w -W -o /test1 --dfs.pool <pool> --dfs.cont <cont>"
+  - "ior -a DFS -w -W -r -R -o /test2 -b 1g -t 4m -C --dfs.pool <pool> --dfs.cont <cont>"
+  - "ior -a DFS -w -r -o /test3 -b 8g -t 1m -C --dfs.pool <pool> --dfs.cont <cont>"
 
 Running mdtest, the user needs to specify a directory with -d where the test
 tree will be created (set '/' if writing to the root of the DFS container). Some
 examples:
-  - "mdtest -a DFS -n 100 -F -D -d / --dfs.pool <pool_uuid> --dfs.svcl <svc_ranks> --dfs.cont <co_uuid>"
-  - "mdtest -a DFS -n 1000 -F -C -d / --dfs.pool <pool_uuid> --dfs.svcl <svc_ranks> --dfs.cont <co_uuid>"
-  - "mdtest -a DFS -I 10 -z 5 -b 2 -L -d / --dfs.pool <pool_uuid> --dfs.svcl <svc_ranks> --dfs.cont <co_uuid>"
+  - "mdtest -a DFS -n 100 -F -D -d / --dfs.pool <pool> --dfs.cont <cont>"
+  - "mdtest -a DFS -n 1000 -F -C -d / --dfs.pool <pool> --dfs.cont <cont>"
+  - "mdtest -a DFS -I 10 -z 5 -b 2 -L -d / --dfs.pool <pool> --dfs.cont <cont>"


### PR DESCRIPTION
- DAOS API now supports identifying pool and containers as labels in
addition to the older way of uuids. Add support for that in the DFS
driver.

- The SVCL has long since been removed from DAOS (since before 1.2 version),
so remove that from the ior code base as no one is using a version requiring
the svcl anymore.

Signed-off-by: Mohamad Chaarawi <mohamad.chaarawi@intel.com>